### PR TITLE
purge 기능의 버그를 수정하였습니다.

### DIFF
--- a/src/Common/LinuxKernel.vala
+++ b/src/Common/LinuxKernel.vala
@@ -108,6 +108,7 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 	// dep: uname
 	public static string check_running_kernel(){
 		string ver = "";
+		string full_ver = "";
 		
 		string std_out;
 		exec_sync("uname -r", out std_out, null);
@@ -116,7 +117,14 @@ public class LinuxKernel : GLib.Object, Gee.Comparable<LinuxKernel> {
 		ver = std_out.strip().replace("\n","");
 		log_msg("Running kernel" + ": %s".printf(ver));
 
-		return ver;
+		//  add kernel compile version
+		exec_sync("uname -v",out std_out, null);
+		log_debug(std_out);
+
+		full_ver = ver + "." + std_out.split_set("#-")[1];
+		log_msg("Running kernel version" + ": %s".printf(std_out));
+
+		return full_ver;
 	}
 
 	public static void initialize_regex(){


### PR DESCRIPTION
기존에 아래 이미지와 같이 '오래된 커널 지우기' 기능에서 같은 버전의 컴파일 번호가 다른 커널이 리스트에 포함되지 않는 버그가 발견 되었습니다.
![image](https://user-images.githubusercontent.com/55476302/122664163-93579b80-d1da-11eb-8a5f-a4731d56f4f9.png)

이를 해결하기 위해 실행중인 커널의 버전 체크에 컴파일 번호를 포함하도록 수정하였습니다.
![image](https://user-images.githubusercontent.com/55476302/122664180-b5511e00-d1da-11eb-9369-fa7ec82a11aa.png)
